### PR TITLE
[BUGFIX] Fix two conditions in RestrictionManager class

### DIFF
--- a/src/MembersBundle/Manager/RestrictionManager.php
+++ b/src/MembersBundle/Manager/RestrictionManager.php
@@ -63,7 +63,7 @@ class RestrictionManager implements RestrictionManagerInterface
 
         if ($element instanceof Document) {
             $restriction = $this->getRestrictionElement($element, 'page');
-        } elseif ($element instanceof DataObject) {
+        } elseif ($element instanceof DataObject\Concrete) {
             $restriction = $this->getRestrictionElement($element, 'object');
         } elseif ($element instanceof Asset) {
             $restriction = $this->getRestrictionElement($element, 'asset');
@@ -94,7 +94,7 @@ class RestrictionManager implements RestrictionManagerInterface
         $restriction = false;
         if ($element instanceof Document) {
             $restriction = $this->getRestrictionElement($element, 'page');
-        } elseif ($element instanceof DataObject) {
+        } elseif ($element instanceof DataObject\Concrete) {
             $restriction = $this->getRestrictionElement($element, 'object');
         } elseif ($element instanceof Asset) {
             $restriction = $this->getRestrictionElement($element, 'asset');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | dev-master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #115

Change 
`} elseif ($element instanceof DataObject) {` to
`} elseif ($element instanceof DataObject\Concrete) {` in functions
`getElementRestrictedGroups(...)` and `getElementRestrictionStatus(...)` because Custom Objects extend `Pimcore\Model\DataObject\Concrete`.

Otherwise the condition does (not) match randomly.